### PR TITLE
Fix hardcoded input path

### DIFF
--- a/src/in/saran/Main.java
+++ b/src/in/saran/Main.java
@@ -17,18 +17,20 @@ public class Main {
         int remainingFuel =0;
         int fuelNeeded = 0;
         try {
-            File f = new File("/Users/saranjith/Desktop/adventofcode/step1/in/saran/mySanta/input.txt");
-            BufferedReader b = new BufferedReader(new FileReader(f));
-            String readLine = "";
-            while ((readLine = b.readLine()) != null) {
-                remainingFuel = retFuel(readLine);
-                fuelNeeded+=remainingFuel;
-                while (remainingFuel>=9) {
-                    remainingFuel = retFuel(String.valueOf(remainingFuel));
-                    fuelNeeded+=remainingFuel;
+            String path = args.length > 0 ? args[0] : "input.txt";
+            File f = new File(path);
+            try (BufferedReader b = new BufferedReader(new FileReader(f))) {
+                String readLine;
+                while ((readLine = b.readLine()) != null) {
+                    remainingFuel = retFuel(readLine);
+                    fuelNeeded += remainingFuel;
+                    while (remainingFuel >= 9) {
+                        remainingFuel = retFuel(String.valueOf(remainingFuel));
+                        fuelNeeded += remainingFuel;
+                    }
                 }
             }
-            System.out.println("Fuel Needed "+fuelNeeded);
+            System.out.println("Fuel Needed " + fuelNeeded);
 
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
## Summary
- allow specifying the input file via command-line argument and default to `input.txt`
- use try-with-resources when opening the input file

## Testing
- `javac -d out src/in/saran/Main.java`
- `java -cp out in.saran.Main input.txt`

------
https://chatgpt.com/codex/tasks/task_e_684d93e54a54832b830b376e11fd6eab